### PR TITLE
build(traefik): Set TLSv1.0 as min and force SNI

### DIFF
--- a/releases/traefik.yaml
+++ b/releases/traefik.yaml
@@ -25,3 +25,6 @@ spec:
       enabled: true
       enforced: true
       permanentRedirect: true
+      tlsMinVersion: "VersionTLS10"
+      sniStrict: true
+      


### PR DESCRIPTION
Sets TLSv1.0 as the minimum, anything below that is insecure.

Forces SNI, forces Traefik to check domain name when checking SSL connection.