### PR TITLE
feat(workloads): separate database-viewer into dev and prod environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ kubeseal --format=yaml --controller-name=sealed-secrets -n [NAMESPACE] -- < secr
 ## Workloads
 
 - Shabad OS Website
-- Shabad OS Database Viewer
+- Shabad OS Database Viewer Dev
+- Shabad OS Database Viewer Production
 - Shabad OS Database on MariaDB
 - GurbaniNow Dev API
 - GurbaniNow Prod API

--- a/workloads/database-viewer--dev.yaml
+++ b/workloads/database-viewer--dev.yaml
@@ -2,30 +2,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: database-viewer-deployment
+  name: database-viewer-deployment--dev
   namespace: shabad-os
   labels:
-    app: database-viewer
+    app: database-viewer--dev
   annotations:
     fluxcd.io/automated: "true"
+    fluxcd.io/tag.database-viewer--dev: regexp:^(v\d*\.\d*\.\d*-next\.\d*)$
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: database-viewer
+      app: database-viewer--dev
   template:
     metadata:
       labels:
-        app: database-viewer
+        app: database-viewer--dev
     spec:
       containers:
       - image: shabados/database-viewer-frontend:v1.4.3-next.2
-        name: database-viewer-frontend
+        name: database-viewer-frontend--dev
         ports:
         - containerPort: 52526
           name: http
       - image: shabados/database-viewer-backend:v1.4.3-next.2
-        name: database-viewer-backend
+        name: database-viewer-backend--dev
         command: ["npm", "run", "start:production"]
         env:
         - name: PORT
@@ -46,11 +47,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: database-viewer-service
+  name: database-viewer-service--dev
   namespace: shabad-os
 spec:
   selector:
-    app: database-viewer
+    app: database-viewer--dev
   ports:
   - name: backend
     port: 52526
@@ -62,21 +63,21 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: database-viewer-ingress
+  name: database-viewer-ingress--dev
   namespace: shabad-os
   annotations:
     kubernetes.io/ingress.class: traefik
     traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:
-  - host: viewer.shabados.com
+  - host: viewer.dev.shabados.com
     http:
       paths:
       - path: /api
         backend:
-          serviceName: database-viewer-service
+          serviceName: database-viewer-service--dev
           servicePort: backend
       - path: /
         backend:
-          serviceName: database-viewer-service
+          serviceName: database-viewer-service--dev
           servicePort: frontend

--- a/workloads/database-viewer--production.yaml
+++ b/workloads/database-viewer--production.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: database-viewer-deployment--production
+  namespace: shabad-os
+  labels:
+    app: database-viewer--production
+  annotations:
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.database-viewer--production: regexp:^(v\d*\.\d*\.\d*)$
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: database-viewer--production
+  template:
+    metadata:
+      labels:
+        app: database-viewer--production
+    spec:
+      containers:
+      - image: shabados/database-viewer-frontend:v1.4.3-next.2
+        name: database-viewer-frontend--production
+        ports:
+        - containerPort: 52526
+          name: http
+      - image: shabados/database-viewer-backend:v1.4.3-next.2
+        name: database-viewer-backend--production
+        command: ["npm", "run", "start:production"]
+        env:
+        - name: PORT
+          value: "52526"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/auth/google/credentials.json
+        volumeMounts:
+        - mountPath: /var/auth/google
+          name: google-application-credentials
+        ports:
+        - containerPort: 80
+          name: http
+      volumes:
+      - name: google-application-credentials
+        secret:
+          secretName: google-application-credentials
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: database-viewer-service--production
+  namespace: shabad-os
+spec:
+  selector:
+    app: database-viewer--production
+  ports:
+  - name: backend
+    port: 52526
+    targetPort: 52526
+  - name: frontend
+    port: 80
+    targetPort: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: database-viewer-ingress--production
+  namespace: shabad-os
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.frontend.rule.type: PathPrefixStrip
+spec:
+  rules:
+  - host: viewer.dev.shabados.com
+    http:
+      paths:
+      - path: /api
+        backend:
+          serviceName: database-viewer-service--production
+          servicePort: backend
+      - path: /
+        backend:
+          serviceName: database-viewer-service--production
+          servicePort: frontend


### PR DESCRIPTION
### Summary of PR
Provisions viewer's dev and prod environments, moving from the single prod environment. Uses semver strings now.


### Linked issues
Related #9 